### PR TITLE
En Dash Time Separator

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -367,7 +367,7 @@ function bpwfwp_print_opening_hours() {
 			} elseif ( empty( $end ) ) {
 				$time = __( 'Open from ', 'business-profile' ) . $start->format( get_option( 'time_format' ) );
 			} else {
-				$time = $start->format( get_option( 'time_format' ) ) . _x( '-', 'Separator between opening and closing times. Example: 9:00am-5:00pm', 'business-profile' ) . $end->format( get_option( 'time_format' ) );
+				$time = $start->format( get_option( 'time_format' ) ) . _x( '&thinsp;&ndash;&thinsp;', 'Separator between opening and closing times. Example: 9:00am-5:00pm', 'business-profile' ) . $end->format( get_option( 'time_format' ) );
 			}
 		}
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -316,14 +316,14 @@ function bpwfwp_print_opening_hours() {
 				} elseif ( empty( $end ) ) {
 					$string = sprintf( _x( '%s open from %s', 'Brief opening hours description which lists the days followed by the opening time. Example: Mo,Tu,We open from 9:00am', 'business-profile' ), $days_string, $start->format( get_option( 'time_format' ) ) );
 				} else {
-					$string = sprintf( _x( '%s %s-%s', 'Brief opening hours description which lists the days followed by the opening and closing times. Example: Mo,Tu,We 9:00am-5:00pm', 'business-profile' ), $days_string, $start->format( get_option( 'time_format' ) ),  $end->format( get_option( 'time_format' ) ) );
+					$string = sprintf( _x( '%s %s&thinsp;&ndash;&thinsp;%s', 'Brief opening hours description which lists the days followed by the opening and closing times. Example: Mo,Tu,We 9:00am&thinsp;&ndash;&thinsp;5:00pm', 'business-profile' ), $days_string, $start->format( get_option( 'time_format' ) ),  $end->format( get_option( 'time_format' ) ) );
 				}
 			}
 
 			$slots[] = $string;
 		}
 
-		echo join( _x( '; ', 'Separator between multiple opening times in the brief opening hours. Example: Mo,We 9:00 AM - 5:00 PM; Tu,Th 10:00 AM - 5:00 PM', 'business-profile' ), $slots );
+		echo join( _x( '; ', 'Separator between multiple opening times in the brief opening hours. Example: Mo,We 9:00 am&thinsp;&ndash;&thinsp;5:00 pm; Tu,Th 10:00 am&thinsp;&ndash;&thinsp;5:00 pm', 'business-profile' ), $slots );
 	?>
 
 	</div>
@@ -367,7 +367,7 @@ function bpwfwp_print_opening_hours() {
 			} elseif ( empty( $end ) ) {
 				$time = __( 'Open from ', 'business-profile' ) . $start->format( get_option( 'time_format' ) );
 			} else {
-				$time = $start->format( get_option( 'time_format' ) ) . _x( '&thinsp;&ndash;&thinsp;', 'Separator between opening and closing times. Example: 9:00am-5:00pm', 'business-profile' ) . $end->format( get_option( 'time_format' ) );
+				$time = $start->format( get_option( 'time_format' ) ) . _x( '&thinsp;&ndash;&thinsp;', 'Separator between opening and closing times. Example: 9:00am&thinsp;&ndash;&thinsp;5:00pm', 'business-profile' ) . $end->format( get_option( 'time_format' ) );
 			}
 		}
 


### PR DESCRIPTION
This is my first ever pull request for anything. Hope I’m doing it right. You’ve got a good little plugin, thank you. This will make the time separators look more professional.

“Use close-set* en dashes… between digits to indicate range.”
—Elements of Typographic Style (pg 80)

Only way to do that without more js/css is with `&thinsp;`

The `&ndash;` is critical, the thin space not as much.