### PR TITLE
Seems to fix issue with the address passed to Google when getting directions.

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -215,7 +215,7 @@ if ( ! function_exists( 'bpwfwp_print_address' ) ) {
 
 		<?php if ( bpfwp_get_display( 'show_get_directions' ) ) : ?>
 		<div class="bp-directions">
-			<a href="//maps.google.com/maps?saddr=current+location&daddr=<?php echo urlencode( esc_attr( $address['text'] ) ); ?>" target="_blank"><?php _e( 'Get directions', 'business-profile' ); ?></a>
+			<a href="//maps.google.com/maps?saddr=current+location&daddr=<?php echo $address['text']; ?>" target="_blank"><?php _e( 'Get directions', 'business-profile' ); ?></a>
 		</div>
 		<?php endif;
 


### PR DESCRIPTION
Encoding a business with an apostrophe in the name put &#039; in the search field, so it seems urlencode() is not appropriate here and esc_attr() does not seem to be necessary here, either. After this change, I correctly get directions instead of an error. I think I would get an error even without the apostrophe since I think the esc_attr was removing separations for the address lines, which now correctly appear as commas.